### PR TITLE
fix: update named imports from deno std

### DIFF
--- a/deno/zstd.ts
+++ b/deno/zstd.ts
@@ -1,5 +1,5 @@
 
-import { decode } from "https://deno.land/std/encoding/base64.ts"
+import { decodeBase64 } from "https://deno.land/std/encoding/base64.ts"
 import { wasm } from "./zstd.encoded.wasm.ts"
 import Module from './zstd.deno.js';
 
@@ -9,7 +9,7 @@ const initialized = (() =>
   }))();
 
 export const init = async () => {
-  const bytes = decode(wasm);
+  const bytes = decodeBase64(wasm);
   Module['init'](bytes);
   await initialized;
 };


### PR DESCRIPTION
## Description
This pull request addresses recently removed deprecations in the Deno std library ([0.210.0](https://github.com/denoland/deno_std/releases/tag/0.210.0)). It updates o use the decode funtion import to new decodeBase64 named import. This change ensures compatibility with the latest versions of Deno.

- https://github.com/denoland/deno_std/pull/3952