### PR TITLE
Stop using readFileSync

### DIFF
--- a/examples/node-esm-dict/index.mjs
+++ b/examples/node-esm-dict/index.mjs
@@ -1,12 +1,12 @@
 import { init, decompressUsingDict, createDCtx, compressUsingDict, createCCtx } from '@bokuweb/zstd-wasm';
-import { readFileSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { resolve, dirname } from 'path';
 
 (async () => {
   await init();
   const buf = Buffer.from('Hello zstd!!');
   const dir = dirname(new URL(import.meta.url).pathname)
-  const dict = readFileSync(resolve(dir, './json-dict'));
+  const dict = await readFile(resolve(dir, './json-dict'));
   const compressed = compressUsingDict(createCCtx(), buf, dict, 10);
   const decompressed = decompressUsingDict(createDCtx(), compressed, dict);
   const res = Buffer.from(decompressed).toString();

--- a/lib/index.node.ts
+++ b/lib/index.node.ts
@@ -1,9 +1,9 @@
 import { Module, waitInitialized } from './module';
 
 export const init = async () => {
-  const { readFileSync } = require('fs');
+  const { readFile } = require('fs/promises');
   const { resolve } = require('path');
-  const buf = readFileSync(resolve(__dirname, './wasm/zstd.wasm'));
+  const buf = await readFile(resolve(__dirname, './wasm/zstd.wasm'));
   Module['init'](buf);
   await waitInitialized();
 };

--- a/test/compress_using_dict.test.ts
+++ b/test/compress_using_dict.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 
 import { decompressUsingDict, createDCtx } from '../lib/simple/decompress_using_dict';
@@ -7,8 +7,8 @@ import { init } from '../lib/index.node';
 
 test('using dict', async () => {
   await init();
-  const buf = readFileSync(resolve(__dirname, './mock/mock.json'));
-  const dict = readFileSync(resolve(__dirname, './json-dict'));
+  const buf = await readFile(resolve(__dirname, './mock/mock.json'));
+  const dict = await readFile(resolve(__dirname, './json-dict'));
   const compressed = compressUsingDict(createCCtx(), buf, dict, 10);
   const decompressed = decompressUsingDict(createDCtx(), compressed, dict);
   expect(buf.toString()).toBe(Buffer.from(decompressed).toString());

--- a/test/largefile.test.ts
+++ b/test/largefile.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 
 import { decompress } from '../lib/simple/decompress';
@@ -7,7 +7,7 @@ import { init } from '../lib/index.node';
 
 test('largefile', async () => {
   await init();
-  const buf = readFileSync(resolve(__dirname, './large-file'));
+  const buf = await readFile(resolve(__dirname, './large-file'));
   const compressed = compress(buf, 10);
   const decompressed = decompress(compressed);
   expect(buf.equals(Buffer.from(decompressed))).toBeTruthy();


### PR DESCRIPTION
This ensures we don't block the event loop while reading files, which should result in a overall system performance improvement.

This closes #129.